### PR TITLE
Fixes the position of small sub-icons in masthead

### DIFF
--- a/client/galaxy/style/scss/base.scss
+++ b/client/galaxy/style/scss/base.scss
@@ -430,10 +430,10 @@ div.unified-panel-body-background {
                 font-weight: bold;
                 font-size: 10px;
                 position: relative;
-                left: 30px;
-                top: -15px;
+                right: 5px;
+                top: 10px;
                 color: gold;
-                height: 0px;
+                width:0px;
             }
         }
     }


### PR DESCRIPTION
This repositions the small icons which we use under the larger scratchbook icons.