### PR TITLE
Consolidate portlet classes, fix tool form views

### DIFF
--- a/client/galaxy/scripts/mvc/form/form-repeat.js
+++ b/client/galaxy/scripts/mvc/form/form-repeat.js
@@ -55,7 +55,7 @@ export var View = Backbone.View.extend({
         var portlet = new Portlet.View({
             id: options.id,
             title: _l("placeholder"),
-            cls: options.cls || "ui-portlet-repeat",
+            cls: options.cls || "ui-portlet-section",
             operations: { button_delete: button_delete }
         });
         portlet.append(options.$el);

--- a/client/galaxy/scripts/mvc/form/form-view.js
+++ b/client/galaxy/scripts/mvc/form/form-view.js
@@ -9,7 +9,7 @@ export default Backbone.View.extend({
     initialize: function(options) {
         this.model = new Backbone.Model({
             initial_errors: false,
-            cls: "ui-portlet-limited",
+            cls: "ui-portlet",
             icon: null,
             always_refresh: true,
             status: "warning",
@@ -131,8 +131,8 @@ export default Backbone.View.extend({
             icon: options.icon,
             title: options.title,
             title_id: options.title_id,
-            cls: options.cls,
             operations: !options.hide_operations && options.operations,
+            cls: options.cls,
             buttons: options.buttons,
             collapsible: options.collapsible,
             collapsed: options.collapsed,

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -71,7 +71,7 @@ var View = Backbone.View.extend({
                     cls_disable: "fa fa-undo",
                     errors: step.messages,
                     initial_errors: true,
-                    cls: "ui-portlet-narrow",
+                    cls: "ui-portlet-section",
                     hide_operations: true,
                     needs_refresh: false,
                     always_refresh: step.step_type != "tool"
@@ -269,7 +269,7 @@ var View = Backbone.View.extend({
             this.wp_form = new Form({
                 title: "<b>Workflow Parameters</b>",
                 inputs: this.wp_inputs,
-                cls: "ui-portlet-narrow",
+                cls: "ui-portlet-section",
                 onchange: function() {
                     _.each(self.wp_form.input_list, (input_def, i) => {
                         _.each(input_def.links, step => {
@@ -285,7 +285,7 @@ var View = Backbone.View.extend({
     /** Render workflow parameters */
     _renderHistory: function() {
         this.history_form = new Form({
-            cls: "ui-portlet-narrow",
+            cls: "ui-portlet-section",
             title: "<b>History Options</b>",
             inputs: [
                 {
@@ -322,7 +322,7 @@ var View = Backbone.View.extend({
         this.workflow_resource_parameters_form = null;
         if (!_.isEmpty(this.model.get("workflow_resource_parameters"))) {
             this.workflow_resource_parameters_form = new Form({
-                cls: "ui-portlet-narrow",
+                cls: "ui-portlet-section",
                 title: "<b>Workflow Resource Options</b>",
                 inputs: this.model.get("workflow_resource_parameters")
             });
@@ -343,7 +343,7 @@ var View = Backbone.View.extend({
         this.display_use_cached_job_checkbox = display_use_cached_job_checkbox === "true";
         if (this.display_use_cached_job_checkbox) {
             this.job_options_form = new Form({
-                cls: "ui-portlet-narrow",
+                cls: "ui-portlet-section",
                 title: "<b>Job re-use Options</b>",
                 inputs: [
                     {

--- a/client/galaxy/scripts/mvc/tool/tool-form-composite.js
+++ b/client/galaxy/scripts/mvc/tool/tool-form-composite.js
@@ -26,7 +26,7 @@ var View = Backbone.View.extend({
         this.setElement(
             $("<div/>")
                 .addClass("ui-form-composite")
-                .append((this.$message = $("<div/>")))
+                .append((this.$message = $("<div/>").addClass("mb-4")))
                 .append((this.$header = $("<div/>")))
                 .append((this.$steps = $("<div/>")))
         );
@@ -227,10 +227,10 @@ var View = Backbone.View.extend({
             }
         });
         this.$header
-            .addClass("ui-form-header")
+            .addClass("h4")
             .empty()
             .append(`<b>Workflow: ${this.model.get("name")}<b>`)
-            .append(this.execute_btn.$el);
+            .append(this.execute_btn.$el.addClass("float-right mt-3"));
     },
 
     /** Render message */

--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -225,7 +225,7 @@ export var View = Backbone.View.extend({
                 $("<div/>")
                     .addClass("portlet-content")
                     .append($("<div/>").addClass("portlet-body"))
-                    .append($("<div/>").addClass("portlet-buttons"))
+                    .append($("<div/>").addClass("portlet-buttons mt-3"))
             )
             .append($("<div/>").addClass("portlet-backdrop"));
     }

--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -17,7 +17,7 @@ export var View = Backbone.View.extend({
                 scrollable: true,
                 operations: null,
                 collapsible: false,
-                collapsible_button: false,
+                collapsible_button: true,
                 collapsed: false,
                 onchange_title: null
             }).set(options);
@@ -104,7 +104,7 @@ export var View = Backbone.View.extend({
 
         // render operations
         this.$operations.empty;
-        if (options.collapsible_button) {
+        if (options.collapsible && options.collapsible_button) {
             this.$operations.append(this.collapsible_button.$el);
         }
         if (options.operations) {
@@ -185,16 +185,14 @@ export var View = Backbone.View.extend({
     /** Collapse portlet */
     collapse: function() {
         this.collapsed = true;
-        this.$content.height("0%");
-        this.$body.hide();
+        this.$content.hide();
         this.collapsible_button.setIcon("fa-eye-slash");
     },
 
     /** Expand portlet */
     expand: function() {
         this.collapsed = false;
-        this.$content.height("100%");
-        this.$body.fadeIn("fast");
+        this.$content.show();
         this.collapsible_button.setIcon("fa-eye");
     },
 

--- a/client/galaxy/scripts/mvc/ui/ui-portlet.js
+++ b/client/galaxy/scripts/mvc/ui/ui-portlet.js
@@ -66,7 +66,7 @@ export var View = Backbone.View.extend({
         if (options.icon) {
             this.$title_icon
                 .removeClass()
-                .addClass("portlet-title-icon fa")
+                .addClass("portlet-title-icon fa mr-1")
                 .addClass(options.icon)
                 .show();
         } else {

--- a/client/galaxy/scripts/mvc/visualization/chart/views/groups.js
+++ b/client/galaxy/scripts/mvc/visualization/chart/views/groups.js
@@ -105,7 +105,6 @@ export default Backbone.View.extend({
         this.listenTo(this.chart.groups, "add", function(group) {
             self.repeat.add({
                 id: group.id,
-                cls: "ui-portlet-panel",
                 $el: new GroupView(self.app, { group: group }).$el,
                 ondel: function() {
                     self.chart.groups.remove(group);

--- a/client/galaxy/scripts/mvc/workflow/workflow-forms.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-forms.js
@@ -42,7 +42,7 @@ var Tool = Backbone.View.extend({
                 text_disable: "Set at Runtime",
                 narrow: true,
                 initial_errors: true,
-                cls: "ui-portlet-narrow",
+                cls: "ui-portlet-section",
                 initialmodel: function(process, form) {
                     self._customize(form);
                     process.resolve();

--- a/client/galaxy/scripts/mvc/workflow/workflow-view.js
+++ b/client/galaxy/scripts/mvc/workflow/workflow-view.js
@@ -704,7 +704,7 @@ export default Backbone.View.extend({
             content.workflow = this.workflow;
             content.datatypes = this.datatypes;
             content.icon = WorkflowIcons[node.type];
-            content.cls = "ui-portlet-narrow";
+            content.cls = "ui-portlet-section";
             if (node) {
                 var form_type = node.type == "tool" ? "Tool" : "Default";
                 $el.append(new FormWrappers[form_type](content).form.$el);

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -428,39 +428,10 @@ $ui-margin-horizontal-large: $margin-v * 2;
         border-bottom: solid darken($side-panel-bg, 10%) 1px;
         border-bottom-left-radius: 0px;
         border-top-left-radius: 0px;
-        padding: 0px 2px;
+        padding: 5px;
     }
     .portlet-content {
         padding-right: 0px;
-        margin-left: 5px;
-    }
-}
-
-.ui-portlet-narrow {
-    @extend .ui-portlet;
-    border: none;
-    margin-bottom: $ui-margin-vertical-large;
-    .portlet-header {
-        border-radius: $border-radius-base;
-        .portlet-operations {
-            .ui-button-icon {
-                margin-left: 3px;
-            }
-        }
-    }
-    .ui-portlet-section {
-        .portlet-header {
-            border-radius: $border-radius-large;
-            border-bottom-left-radius: 0px;
-            border-top-left-radius: 0px;
-        }
-    }
-    .portlet-content {
-        padding: 0px;
-    }
-    .ui-table-section,
-    .ui-portlet-section .portlet-content {
-        padding-left: $ui-margin-horizontal;
     }
 }
 

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -374,96 +374,34 @@ $ui-margin-horizontal-large: $margin-v * 2;
 }
 
 .ui-form-composite {
-    max-width: 900px;
     height: 100%;
     flex-direction: column;
     display: flex;
-    .ui-form-header {
-        @extend h3;
-        margin-top: 0px;
-        .ui-label {
-            width: calc(100% - 200px);
-        }
-    }
     .ui-steps {
         overflow: auto;
-        margin-top: 15px;
-        border: dashed 1px darken($form-heading-bg, 30%);
-        border-radius: $border-radius-base;
-        padding: $ui-margin-horizontal;
-        .ui-portlet-narrow {
-            .portlet-header {
-                padding: 1px 5px 0px 8px;
-            }
-            padding: 0px $ui-margin-horizontal 0px $ui-margin-horizontal;
-            .portlet-content {
-                padding: 0px $ui-margin-horizontal 0px $ui-margin-horizontal;
-            }
-            .ui-table-section,
-            .ui-portlet-repeat .portlet-content {
-                padding-left: $ui-margin-horizontal-large;
-            }
-        }
-    }
-    .ui-message {
-        margin-top: 0px;
-        margin-bottom: 10px;
     }
 }
 
 // portlets
 .ui-portlet {
     @extend .card;
-    position: relative;
-    clear: both;
-    width: auto;
-    height: auto;
+    height: 100%;
     .portlet-header {
         @extend .card-header;
-        overflow: visible;
-        width: 100%;
         .portlet-title {
-            word-wrap: break-word;
-            .portlet-title-text {
-                @extend h4;
-                vertical-align: middle;
-                //line-height: 22px;
-            }
-            .portlet-title-text.no-highlight.collapsible {
+            .portlet-title-text.collapsible {
                 cursor: pointer;
                 text-decoration: underline;
             }
-            .portlet-title-icon {
-                font-size: 1.2em;
-                vertical-align: middle;
-                margin-right: 5px;
-            }
         }
         .portlet-operations {
-            .ui-button-icon {
-                margin-left: $ui-margin-horizontal;
+            > * {
+                @extend .ml-1;
             }
         }
     }
     .portlet-content {
         @extend .card-body;
-        clear: both;
-        .portlet-body {
-            padding: 0px;
-            height: 100%;
-            width: 100%;
-        }
-        .portlet-buttons {
-            margin-top: $ui-margin-vertical-large;
-            margin-bottom: $ui-margin-vertical-large;
-            > .btn {
-                margin-right: 5px;
-            }
-        }
-    }
-    .portlet-content.nopadding,
-    .portlet-body.nopadding {
-        padding: 0px;
     }
     .portlet-backdrop {
         display: none;
@@ -490,10 +428,6 @@ $ui-margin-horizontal-large: $margin-v * 2;
         border-bottom-left-radius: 0px;
         border-top-left-radius: 0px;
         padding: 0px 2px;
-        .portlet-title-text {
-            vertical-align: middle;
-            line-height: 20px !important;
-        }
     }
     .portlet-content {
         padding-right: 0px;

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -402,6 +402,8 @@ $ui-margin-horizontal-large: $margin-v * 2;
     }
     .portlet-content {
         @extend .card-body;
+        @extend .pl-2;
+        @extend .pr-2;
     }
     .portlet-backdrop {
         display: none;
@@ -419,19 +421,19 @@ $ui-margin-horizontal-large: $margin-v * 2;
 .ui-portlet-section {
     @extend .ui-portlet;
     border: none;
-    border-left: solid 3px $side-panel-bg;
+    border-left: solid 3px $gray-200;
     border-radius: $border-radius-large;
     margin-bottom: $ui-margin-vertical;
     .portlet-header {
-        background: $side-panel-bg;
+        background: $gray-200;
         border-radius: $border-radius-large;
-        border-bottom: solid darken($side-panel-bg, 10%) 1px;
+        border-bottom: solid darken($gray-200, 10%) 1px;
         border-bottom-left-radius: 0px;
         border-top-left-radius: 0px;
         padding: 5px;
     }
     .portlet-content {
-        padding-right: 0px;
+        @extend .pr-0;
     }
 }
 

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -368,7 +368,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
 }
 
 .ui-form-section {
-    border-left: solid 3px $form-heading-bg;
+    border-left: solid 3px $side-panel-bg;
     border-radius: $border-radius-large !important;
     padding-left: 10px;
 }
@@ -416,43 +416,28 @@ $ui-margin-horizontal-large: $margin-v * 2;
     }
 }
 
-.ui-portlet-repeat {
+.ui-portlet-section {
     @extend .ui-portlet;
     border: none;
-    border-left: solid 3px $form-heading-bg;
+    border-left: solid 3px $side-panel-bg;
     border-radius: $border-radius-large;
     margin-bottom: $ui-margin-vertical;
     .portlet-header {
-        background: $form-heading-bg;
+        background: $side-panel-bg;
         border-radius: $border-radius-large;
+        border-bottom: solid darken($side-panel-bg, 10%) 1px;
         border-bottom-left-radius: 0px;
         border-top-left-radius: 0px;
         padding: 0px 2px;
     }
     .portlet-content {
         padding-right: 0px;
-    }
-}
-
-.ui-portlet-panel {
-    @extend .ui-portlet-repeat;
-    margin-top: $ui-margin-vertical;
-    border-left: solid 3px $side-panel-bg;
-    .portlet-header {
-        background: $side-panel-bg;
-        border-bottom: solid darken($side-panel-bg, 10%) 1px;
-    }
-}
-
-.ui-portlet-section {
-    @extend .ui-portlet-panel;
-    .portlet-highlight {
-        text-decoration: underline;
+        margin-left: 5px;
     }
 }
 
 .ui-portlet-narrow {
-    @extend .ui-portlet-limited;
+    @extend .ui-portlet;
     border: none;
     margin-bottom: $ui-margin-vertical-large;
     .portlet-header {
@@ -463,7 +448,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
             }
         }
     }
-    .ui-portlet-repeat {
+    .ui-portlet-section {
         .portlet-header {
             border-radius: $border-radius-large;
             border-bottom-left-radius: 0px;
@@ -474,22 +459,14 @@ $ui-margin-horizontal-large: $margin-v * 2;
         padding: 0px;
     }
     .ui-table-section,
-    .ui-portlet-repeat .portlet-content {
+    .ui-portlet-section .portlet-content {
         padding-left: $ui-margin-horizontal;
     }
-}
-
-.ui-portlet-limited {
-    @extend .ui-portlet;
-    max-width: 900px;
 }
 
 .ui-portlet-plain {
     @extend .ui-portlet;
     border: none;
-    .portlet-content {
-        padding: 0px;
-    }
 }
 
 // popovers

--- a/client/galaxy/style/scss/ui.scss
+++ b/client/galaxy/style/scss/ui.scss
@@ -402,8 +402,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
     }
     .portlet-content {
         @extend .card-body;
-        @extend .pl-2;
-        @extend .pr-2;
+        @extend .p-2;
     }
     .portlet-backdrop {
         display: none;
@@ -420,10 +419,10 @@ $ui-margin-horizontal-large: $margin-v * 2;
 
 .ui-portlet-section {
     @extend .ui-portlet;
+    @extend .mb-2;
     border: none;
     border-left: solid 3px $gray-200;
     border-radius: $border-radius-large;
-    margin-bottom: $ui-margin-vertical;
     .portlet-header {
         background: $gray-200;
         border-radius: $border-radius-large;
@@ -433,7 +432,7 @@ $ui-margin-horizontal-large: $margin-v * 2;
         padding: 5px;
     }
     .portlet-content {
-        @extend .pr-0;
+        padding-right: 0px !important;
     }
 }
 

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -72,7 +72,7 @@ hr {
   height: 0;
   overflow: visible; }
 
-h1, h2, h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, .ui-form-composite .ui-form-header, h4, .ui-portlet .portlet-header .portlet-title .portlet-title-text, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text, h5, h6 {
+h1, h2, h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, h4, h5, h6 {
   margin-top: 0;
   margin-bottom: 0.5rem; }
 
@@ -297,7 +297,7 @@ template {
 [hidden] {
   display: none !important; }
 
-h1, h2, h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, .ui-form-composite .ui-form-header, h4, .ui-portlet .portlet-header .portlet-title .portlet-title-text, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text, h5, h6,
+h1, h2, h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, h4, h5, h6,
 .h1, .h2, .h3, .h4, .h5, .h6 {
   margin-bottom: 0.5rem;
   font-family: inherit;
@@ -311,10 +311,10 @@ h1, .h1 {
 h2, .h2 {
   font-size: 1.4rem; }
 
-h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, .ui-form-composite .ui-form-header, .h3 {
+h3, .upload-view-default .upload-box .upload-helper, .upload-view-composite .upload-box .upload-helper, .h3 {
   font-size: 1.2rem; }
 
-h4, .ui-portlet .portlet-header .portlet-title .portlet-title-text, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text, .h4 {
+h4, .h4 {
   font-size: 1rem; }
 
 h5, .h5 {
@@ -5782,7 +5782,7 @@ button.bg-dark:focus {
 .my-1 {
   margin-bottom: 0.25rem !important; }
 
-.ml-1,
+.ml-1, .ui-portlet .portlet-header .portlet-operations > *, .ui-portlet-repeat .portlet-header .portlet-operations > *, .ui-portlet-panel .portlet-header .portlet-operations > *, .ui-portlet-section .portlet-header .portlet-operations > *, .ui-portlet-limited .portlet-header .portlet-operations > *, .ui-portlet-narrow .portlet-header .portlet-operations > *, .ui-portlet-plain .portlet-header .portlet-operations > *,
 .mx-1 {
   margin-left: 0.25rem !important; }
 
@@ -6909,15 +6909,13 @@ a.text-dark:hover, .quota-meter-text a:hover, a.text-dark:focus, .quota-meter-te
   h2,
   h3,
   .upload-view-default .upload-box .upload-helper,
-  .upload-view-composite .upload-box .upload-helper,
-  .ui-form-composite .ui-form-header {
+  .upload-view-composite .upload-box .upload-helper {
     orphans: 3;
     widows: 3; }
   h2,
   h3,
   .upload-view-default .upload-box .upload-helper,
-  .upload-view-composite .upload-box .upload-helper,
-  .ui-form-composite .ui-form-header {
+  .upload-view-composite .upload-box .upload-helper {
     page-break-after: avoid; }
   @page {
     size: a3; }
@@ -10812,77 +10810,17 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
   padding-left: 10px; }
 
 .ui-form-composite {
-  max-width: 900px;
   height: 100%;
   flex-direction: column;
   display: flex; }
-  .ui-form-composite .ui-form-header {
-    margin-top: 0px; }
-    .ui-form-composite .ui-form-header .ui-label {
-      width: calc(100% - 200px); }
   .ui-form-composite .ui-steps {
-    overflow: auto;
-    margin-top: 15px;
-    border: dashed 1px #cb9d39;
-    border-radius: 0.1875rem;
-    padding: 1rem; }
-    .ui-form-composite .ui-steps .ui-portlet-narrow {
-      padding: 0px 1rem 0px 1rem; }
-      .ui-form-composite .ui-steps .ui-portlet-narrow .portlet-header {
-        padding: 1px 5px 0px 8px; }
-      .ui-form-composite .ui-steps .ui-portlet-narrow .portlet-content {
-        padding: 0px 1rem 0px 1rem; }
-      .ui-form-composite .ui-steps .ui-portlet-narrow .ui-table-section,
-      .ui-form-composite .ui-steps .ui-portlet-narrow .ui-portlet-repeat .portlet-content,
-      .ui-form-composite .ui-steps .ui-portlet-narrow .ui-portlet-panel .portlet-content,
-      .ui-form-composite .ui-steps .ui-portlet-narrow .ui-portlet-section .portlet-content {
-        padding-left: 3rem; }
-  .ui-form-composite .ui-message {
-    margin-top: 0px;
-    margin-bottom: 10px; }
+    overflow: auto; }
 
 .ui-portlet, .ui-portlet-repeat, .ui-portlet-panel, .ui-portlet-section, .ui-portlet-limited, .ui-portlet-narrow, .ui-portlet-plain {
-  position: relative;
-  clear: both;
-  width: auto;
-  height: auto; }
-  .ui-portlet .portlet-header, .ui-portlet-repeat .portlet-header, .ui-portlet-panel .portlet-header, .ui-portlet-section .portlet-header, .ui-portlet-limited .portlet-header, .ui-portlet-narrow .portlet-header, .ui-portlet-plain .portlet-header {
-    overflow: visible;
-    width: 100%; }
-    .ui-portlet .portlet-header .portlet-title, .ui-portlet-repeat .portlet-header .portlet-title, .ui-portlet-panel .portlet-header .portlet-title, .ui-portlet-section .portlet-header .portlet-title, .ui-portlet-limited .portlet-header .portlet-title, .ui-portlet-narrow .portlet-header .portlet-title, .ui-portlet-plain .portlet-header .portlet-title {
-      word-wrap: break-word; }
-      .ui-portlet .portlet-header .portlet-title .portlet-title-text, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text {
-        vertical-align: middle; }
-      .ui-portlet .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.no-highlight.collapsible, .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible.ui-button-icon {
-        cursor: pointer;
-        text-decoration: underline; }
-      .ui-portlet .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-section .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-icon, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-icon {
-        font-size: 1.2em;
-        vertical-align: middle;
-        margin-right: 5px; }
-    .ui-portlet .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-repeat .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-panel .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-section .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-limited .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-narrow .portlet-header .portlet-operations .ui-button-icon, .ui-portlet-plain .portlet-header .portlet-operations .ui-button-icon {
-      margin-left: 1rem; }
-  .ui-portlet .portlet-content, .ui-portlet-repeat .portlet-content, .ui-portlet-panel .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-limited .portlet-content, .ui-portlet-narrow .portlet-content, .ui-portlet-plain .portlet-content {
-    clear: both; }
-    .ui-portlet .portlet-content .portlet-body, .ui-portlet-repeat .portlet-content .portlet-body, .ui-portlet-panel .portlet-content .portlet-body, .ui-portlet-section .portlet-content .portlet-body, .ui-portlet-limited .portlet-content .portlet-body, .ui-portlet-narrow .portlet-content .portlet-body, .ui-portlet-plain .portlet-content .portlet-body {
-      padding: 0px;
-      height: 100%;
-      width: 100%; }
-    .ui-portlet .portlet-content .portlet-buttons, .ui-portlet-repeat .portlet-content .portlet-buttons, .ui-portlet-panel .portlet-content .portlet-buttons, .ui-portlet-section .portlet-content .portlet-buttons, .ui-portlet-limited .portlet-content .portlet-buttons, .ui-portlet-narrow .portlet-content .portlet-buttons, .ui-portlet-plain .portlet-content .portlet-buttons {
-      margin-top: 0.75rem;
-      margin-bottom: 0.75rem; }
-      .ui-portlet .portlet-content .portlet-buttons > .btn, .ui-portlet-repeat .portlet-content .portlet-buttons > .btn, .ui-portlet-panel .portlet-content .portlet-buttons > .btn, .ui-portlet-section .portlet-content .portlet-buttons > .btn, .ui-portlet-limited .portlet-content .portlet-buttons > .btn, .ui-portlet-narrow .portlet-content .portlet-buttons > .btn, .ui-portlet-plain .portlet-content .portlet-buttons > .btn, .ui-portlet .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-repeat .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-panel .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-section .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-limited .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-narrow .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet-plain .portlet-content .portlet-buttons > input[type="submit"], .ui-portlet .portlet-content .portlet-buttons >
-      button, .ui-portlet-repeat .portlet-content .portlet-buttons >
-      button, .ui-portlet-panel .portlet-content .portlet-buttons >
-      button, .ui-portlet-section .portlet-content .portlet-buttons >
-      button, .ui-portlet-limited .portlet-content .portlet-buttons >
-      button, .ui-portlet-narrow .portlet-content .portlet-buttons >
-      button, .ui-portlet-plain .portlet-content .portlet-buttons >
-      button, .ui-portlet .portlet-content .portlet-buttons > .action-button, .ui-portlet-repeat .portlet-content .portlet-buttons > .action-button, .ui-portlet-panel .portlet-content .portlet-buttons > .action-button, .ui-portlet-section .portlet-content .portlet-buttons > .action-button, .ui-portlet-limited .portlet-content .portlet-buttons > .action-button, .ui-portlet-narrow .portlet-content .portlet-buttons > .action-button, .ui-portlet-plain .portlet-content .portlet-buttons > .action-button, .ui-portlet .portlet-content .portlet-buttons > .menubutton, .ui-portlet-repeat .portlet-content .portlet-buttons > .menubutton, .ui-portlet-panel .portlet-content .portlet-buttons > .menubutton, .ui-portlet-section .portlet-content .portlet-buttons > .menubutton, .ui-portlet-limited .portlet-content .portlet-buttons > .menubutton, .ui-portlet-narrow .portlet-content .portlet-buttons > .menubutton, .ui-portlet-plain .portlet-content .portlet-buttons > .menubutton {
-        margin-right: 5px; }
-  .ui-portlet .portlet-content.nopadding, .ui-portlet-repeat .portlet-content.nopadding, .ui-portlet-panel .portlet-content.nopadding, .ui-portlet-section .portlet-content.nopadding, .ui-portlet-limited .portlet-content.nopadding, .ui-portlet-narrow .portlet-content.nopadding, .ui-portlet-plain .portlet-content.nopadding,
-  .ui-portlet .portlet-body.nopadding, .ui-portlet-repeat .portlet-body.nopadding, .ui-portlet-panel .portlet-body.nopadding, .ui-portlet-section .portlet-body.nopadding, .ui-portlet-limited .portlet-body.nopadding, .ui-portlet-narrow .portlet-body.nopadding, .ui-portlet-plain .portlet-body.nopadding {
-    padding: 0px; }
+  height: 100%; }
+  .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible {
+    cursor: pointer;
+    text-decoration: underline; }
   .ui-portlet .portlet-backdrop, .ui-portlet-repeat .portlet-backdrop, .ui-portlet-panel .portlet-backdrop, .ui-portlet-section .portlet-backdrop, .ui-portlet-limited .portlet-backdrop, .ui-portlet-narrow .portlet-backdrop, .ui-portlet-plain .portlet-backdrop {
     display: none;
     z-index: 10;
@@ -10905,9 +10843,6 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
     padding: 0px 2px; }
-    .ui-portlet-repeat .portlet-header .portlet-title-text, .ui-portlet-panel .portlet-header .portlet-title-text, .ui-portlet-section .portlet-header .portlet-title-text {
-      vertical-align: middle;
-      line-height: 20px !important; }
   .ui-portlet-repeat .portlet-content, .ui-portlet-panel .portlet-content, .ui-portlet-section .portlet-content {
     padding-right: 0px; }
 

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -3382,7 +3382,7 @@ button:not(:first-child),
     .navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {
       color: #fff; }
 
-.card, .ui-portlet, .ui-portlet-section, .ui-portlet-narrow, .ui-portlet-plain {
+.card, .ui-portlet, .ui-portlet-section, .ui-portlet-plain {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -3392,17 +3392,17 @@ button:not(:first-child),
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem; }
-  .card > hr, .ui-portlet > hr, .ui-portlet-section > hr, .ui-portlet-narrow > hr, .ui-portlet-plain > hr {
+  .card > hr, .ui-portlet > hr, .ui-portlet-section > hr, .ui-portlet-plain > hr {
     margin-right: 0;
     margin-left: 0; }
-  .card > .list-group:first-child .list-group-item:first-child, .ui-portlet > .list-group:first-child .list-group-item:first-child, .ui-portlet-section > .list-group:first-child .list-group-item:first-child, .ui-portlet-narrow > .list-group:first-child .list-group-item:first-child, .ui-portlet-plain > .list-group:first-child .list-group-item:first-child {
+  .card > .list-group:first-child .list-group-item:first-child, .ui-portlet > .list-group:first-child .list-group-item:first-child, .ui-portlet-section > .list-group:first-child .list-group-item:first-child, .ui-portlet-plain > .list-group:first-child .list-group-item:first-child {
     border-top-left-radius: 0.25rem;
     border-top-right-radius: 0.25rem; }
-  .card > .list-group:last-child .list-group-item:last-child, .ui-portlet > .list-group:last-child .list-group-item:last-child, .ui-portlet-section > .list-group:last-child .list-group-item:last-child, .ui-portlet-narrow > .list-group:last-child .list-group-item:last-child, .ui-portlet-plain > .list-group:last-child .list-group-item:last-child {
+  .card > .list-group:last-child .list-group-item:last-child, .ui-portlet > .list-group:last-child .list-group-item:last-child, .ui-portlet-section > .list-group:last-child .list-group-item:last-child, .ui-portlet-plain > .list-group:last-child .list-group-item:last-child {
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem; }
 
-.card-body, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-narrow .portlet-content, .ui-portlet-plain .portlet-content {
+.card-body, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content {
   flex: 1 1 auto;
   padding: 1.25rem; }
 
@@ -3422,14 +3422,14 @@ button:not(:first-child),
 .card-link + .card-link {
   margin-left: 1.25rem; }
 
-.card-header, .ui-portlet .portlet-header, .ui-portlet-section .portlet-header, .ui-portlet-narrow .portlet-header, .ui-portlet-plain .portlet-header {
+.card-header, .ui-portlet .portlet-header, .ui-portlet-section .portlet-header, .ui-portlet-plain .portlet-header {
   padding: 0.75rem 1.25rem;
   margin-bottom: 0;
   background-color: rgba(0, 0, 0, 0.03);
   border-bottom: 1px solid rgba(0, 0, 0, 0.125); }
-  .card-header:first-child, .ui-portlet .portlet-header:first-child, .ui-portlet-section .portlet-header:first-child, .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-plain .portlet-header:first-child {
+  .card-header:first-child, .ui-portlet .portlet-header:first-child, .ui-portlet-section .portlet-header:first-child, .ui-portlet-plain .portlet-header:first-child {
     border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0; }
-  .card-header + .list-group .list-group-item:first-child, .ui-portlet .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-section .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-narrow .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-plain .portlet-header + .list-group .list-group-item:first-child {
+  .card-header + .list-group .list-group-item:first-child, .ui-portlet .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-section .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-plain .portlet-header + .list-group .list-group-item:first-child {
     border-top: 0; }
 
 .card-footer {
@@ -3474,14 +3474,14 @@ button:not(:first-child),
 .card-deck {
   display: flex;
   flex-direction: column; }
-  .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
+  .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-plain {
     margin-bottom: 15px; }
   @media (min-width: 576px) {
     .card-deck {
       flex-flow: row wrap;
       margin-right: -15px;
       margin-left: -15px; }
-      .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
+      .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-plain {
         display: flex;
         flex: 1 0 0%;
         flex-direction: column;
@@ -3492,170 +3492,129 @@ button:not(:first-child),
 .card-group {
   display: flex;
   flex-direction: column; }
-  .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
+  .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-plain {
     margin-bottom: 15px; }
   @media (min-width: 576px) {
     .card-group {
       flex-flow: row wrap; }
-      .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
+      .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-plain {
         flex: 1 0 0%;
         margin-bottom: 0; }
-        .card-group > .card + .card, .card-group > .ui-portlet + .card, .card-group > .ui-portlet-section + .card, .card-group > .ui-portlet-narrow + .card, .card-group > .ui-portlet-plain + .card, .card-group > .card + .ui-portlet, .card-group > .ui-portlet + .ui-portlet, .card-group > .ui-portlet-section + .ui-portlet, .card-group > .ui-portlet-narrow + .ui-portlet, .card-group > .ui-portlet-plain + .ui-portlet, .card-group > .card + .ui-portlet-section, .card-group > .ui-portlet + .ui-portlet-section, .card-group > .ui-portlet-section + .ui-portlet-section, .card-group > .ui-portlet-narrow + .ui-portlet-section, .card-group > .ui-portlet-plain + .ui-portlet-section, .card-group > .card + .ui-portlet-narrow, .card-group > .ui-portlet + .ui-portlet-narrow, .card-group > .ui-portlet-section + .ui-portlet-narrow, .card-group > .ui-portlet-narrow + .ui-portlet-narrow, .card-group > .ui-portlet-plain + .ui-portlet-narrow, .card-group > .card + .ui-portlet-plain, .card-group > .ui-portlet + .ui-portlet-plain, .card-group > .ui-portlet-section + .ui-portlet-plain, .card-group > .ui-portlet-narrow + .ui-portlet-plain, .card-group > .ui-portlet-plain + .ui-portlet-plain {
+        .card-group > .card + .card, .card-group > .ui-portlet + .card, .card-group > .ui-portlet-section + .card, .card-group > .ui-portlet-plain + .card, .card-group > .card + .ui-portlet, .card-group > .ui-portlet + .ui-portlet, .card-group > .ui-portlet-section + .ui-portlet, .card-group > .ui-portlet-plain + .ui-portlet, .card-group > .card + .ui-portlet-section, .card-group > .ui-portlet + .ui-portlet-section, .card-group > .ui-portlet-section + .ui-portlet-section, .card-group > .ui-portlet-plain + .ui-portlet-section, .card-group > .card + .ui-portlet-plain, .card-group > .ui-portlet + .ui-portlet-plain, .card-group > .ui-portlet-section + .ui-portlet-plain, .card-group > .ui-portlet-plain + .ui-portlet-plain {
           margin-left: 0;
           border-left: 0; }
-        .card-group > .card:first-child, .card-group > .ui-portlet:first-child, .card-group > .ui-portlet-section:first-child, .card-group > .ui-portlet-narrow:first-child, .card-group > .ui-portlet-plain:first-child {
+        .card-group > .card:first-child, .card-group > .ui-portlet:first-child, .card-group > .ui-portlet-section:first-child, .card-group > .ui-portlet-plain:first-child {
           border-top-right-radius: 0;
           border-bottom-right-radius: 0; }
-          .card-group > .card:first-child .card-img-top, .card-group > .ui-portlet:first-child .card-img-top, .card-group > .ui-portlet-section:first-child .card-img-top, .card-group > .ui-portlet-narrow:first-child .card-img-top, .card-group > .ui-portlet-plain:first-child .card-img-top,
+          .card-group > .card:first-child .card-img-top, .card-group > .ui-portlet:first-child .card-img-top, .card-group > .ui-portlet-section:first-child .card-img-top, .card-group > .ui-portlet-plain:first-child .card-img-top,
           .card-group > .card:first-child .card-header,
           .card-group > .ui-portlet:first-child .card-header,
           .card-group > .ui-portlet-section:first-child .card-header,
-          .card-group > .ui-portlet-narrow:first-child .card-header,
           .card-group > .ui-portlet-plain:first-child .card-header,
           .card-group > .card:first-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:first-child .portlet-header, .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-plain:first-child .portlet-header,
           .card-group > .card:first-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:first-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet:first-child .portlet-header, .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:first-child .portlet-header,
-          .card-group > .card:first-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
-          .card-group > .card:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:first-child .portlet-header, .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:first-child .portlet-header,
           .card-group > .card:first-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:first-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .card-group > .ui-portlet-plain:first-child .portlet-header {
+          .card-group > .ui-portlet-section:first-child .portlet-header, .card-group > .ui-portlet-plain:first-child .portlet-header {
             border-top-right-radius: 0; }
-          .card-group > .card:first-child .card-img-bottom, .card-group > .ui-portlet:first-child .card-img-bottom, .card-group > .ui-portlet-section:first-child .card-img-bottom, .card-group > .ui-portlet-narrow:first-child .card-img-bottom, .card-group > .ui-portlet-plain:first-child .card-img-bottom,
+          .card-group > .card:first-child .card-img-bottom, .card-group > .ui-portlet:first-child .card-img-bottom, .card-group > .ui-portlet-section:first-child .card-img-bottom, .card-group > .ui-portlet-plain:first-child .card-img-bottom,
           .card-group > .card:first-child .card-footer,
           .card-group > .ui-portlet:first-child .card-footer,
           .card-group > .ui-portlet-section:first-child .card-footer,
-          .card-group > .ui-portlet-narrow:first-child .card-footer,
           .card-group > .ui-portlet-plain:first-child .card-footer {
             border-bottom-right-radius: 0; }
-        .card-group > .card:last-child, .card-group > .ui-portlet:last-child, .card-group > .ui-portlet-section:last-child, .card-group > .ui-portlet-narrow:last-child, .card-group > .ui-portlet-plain:last-child {
+        .card-group > .card:last-child, .card-group > .ui-portlet:last-child, .card-group > .ui-portlet-section:last-child, .card-group > .ui-portlet-plain:last-child {
           border-top-left-radius: 0;
           border-bottom-left-radius: 0; }
-          .card-group > .card:last-child .card-img-top, .card-group > .ui-portlet:last-child .card-img-top, .card-group > .ui-portlet-section:last-child .card-img-top, .card-group > .ui-portlet-narrow:last-child .card-img-top, .card-group > .ui-portlet-plain:last-child .card-img-top,
+          .card-group > .card:last-child .card-img-top, .card-group > .ui-portlet:last-child .card-img-top, .card-group > .ui-portlet-section:last-child .card-img-top, .card-group > .ui-portlet-plain:last-child .card-img-top,
           .card-group > .card:last-child .card-header,
           .card-group > .ui-portlet:last-child .card-header,
           .card-group > .ui-portlet-section:last-child .card-header,
-          .card-group > .ui-portlet-narrow:last-child .card-header,
           .card-group > .ui-portlet-plain:last-child .card-header,
           .card-group > .card:last-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:last-child .portlet-header, .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-plain:last-child .portlet-header,
           .card-group > .card:last-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:last-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet:last-child .portlet-header, .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:last-child .portlet-header,
-          .card-group > .card:last-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
-          .card-group > .card:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:last-child .portlet-header, .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:last-child .portlet-header,
           .card-group > .card:last-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:last-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .card-group > .ui-portlet-plain:last-child .portlet-header {
+          .card-group > .ui-portlet-section:last-child .portlet-header, .card-group > .ui-portlet-plain:last-child .portlet-header {
             border-top-left-radius: 0; }
-          .card-group > .card:last-child .card-img-bottom, .card-group > .ui-portlet:last-child .card-img-bottom, .card-group > .ui-portlet-section:last-child .card-img-bottom, .card-group > .ui-portlet-narrow:last-child .card-img-bottom, .card-group > .ui-portlet-plain:last-child .card-img-bottom,
+          .card-group > .card:last-child .card-img-bottom, .card-group > .ui-portlet:last-child .card-img-bottom, .card-group > .ui-portlet-section:last-child .card-img-bottom, .card-group > .ui-portlet-plain:last-child .card-img-bottom,
           .card-group > .card:last-child .card-footer,
           .card-group > .ui-portlet:last-child .card-footer,
           .card-group > .ui-portlet-section:last-child .card-footer,
-          .card-group > .ui-portlet-narrow:last-child .card-footer,
           .card-group > .ui-portlet-plain:last-child .card-footer {
             border-bottom-left-radius: 0; }
-        .card-group > .card:only-child, .card-group > .ui-portlet:only-child, .card-group > .ui-portlet-section:only-child, .card-group > .ui-portlet-narrow:only-child, .card-group > .ui-portlet-plain:only-child {
+        .card-group > .card:only-child, .card-group > .ui-portlet:only-child, .card-group > .ui-portlet-section:only-child, .card-group > .ui-portlet-plain:only-child {
           border-radius: 0.25rem; }
-          .card-group > .card:only-child .card-img-top, .card-group > .ui-portlet:only-child .card-img-top, .card-group > .ui-portlet-section:only-child .card-img-top, .card-group > .ui-portlet-narrow:only-child .card-img-top, .card-group > .ui-portlet-plain:only-child .card-img-top,
+          .card-group > .card:only-child .card-img-top, .card-group > .ui-portlet:only-child .card-img-top, .card-group > .ui-portlet-section:only-child .card-img-top, .card-group > .ui-portlet-plain:only-child .card-img-top,
           .card-group > .card:only-child .card-header,
           .card-group > .ui-portlet:only-child .card-header,
           .card-group > .ui-portlet-section:only-child .card-header,
-          .card-group > .ui-portlet-narrow:only-child .card-header,
           .card-group > .ui-portlet-plain:only-child .card-header,
           .card-group > .card:only-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:only-child .portlet-header, .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-plain:only-child .portlet-header,
           .card-group > .card:only-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:only-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet:only-child .portlet-header, .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:only-child .portlet-header,
-          .card-group > .card:only-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
-          .card-group > .card:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:only-child .portlet-header, .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:only-child .portlet-header,
           .card-group > .card:only-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:only-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .card-group > .ui-portlet-plain:only-child .portlet-header {
+          .card-group > .ui-portlet-section:only-child .portlet-header, .card-group > .ui-portlet-plain:only-child .portlet-header {
             border-top-left-radius: 0.25rem;
             border-top-right-radius: 0.25rem; }
-          .card-group > .card:only-child .card-img-bottom, .card-group > .ui-portlet:only-child .card-img-bottom, .card-group > .ui-portlet-section:only-child .card-img-bottom, .card-group > .ui-portlet-narrow:only-child .card-img-bottom, .card-group > .ui-portlet-plain:only-child .card-img-bottom,
+          .card-group > .card:only-child .card-img-bottom, .card-group > .ui-portlet:only-child .card-img-bottom, .card-group > .ui-portlet-section:only-child .card-img-bottom, .card-group > .ui-portlet-plain:only-child .card-img-bottom,
           .card-group > .card:only-child .card-footer,
           .card-group > .ui-portlet:only-child .card-footer,
           .card-group > .ui-portlet-section:only-child .card-footer,
-          .card-group > .ui-portlet-narrow:only-child .card-footer,
           .card-group > .ui-portlet-plain:only-child .card-footer {
             border-bottom-right-radius: 0.25rem;
             border-bottom-left-radius: 0.25rem; }
-        .card-group > .card:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) {
+        .card-group > .card:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) {
           border-radius: 0; }
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
+          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-header,
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
+          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-footer,
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-footer {
             border-radius: 0; } }
 
-.card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
+.card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-plain {
   margin-bottom: 0.75rem; }
 
 @media (min-width: 576px) {
@@ -3664,23 +3623,23 @@ button:not(:first-child),
     column-gap: 1.25rem;
     orphans: 1;
     widows: 1; }
-    .card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
+    .card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-plain {
       display: inline-block;
       width: 100%; } }
 
-.accordion .card:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-section:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-narrow:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-plain:not(:first-of-type):not(:last-of-type) {
+.accordion .card:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-section:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-plain:not(:first-of-type):not(:last-of-type) {
   border-bottom: 0;
   border-radius: 0; }
 
-.accordion .card:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .card-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet .portlet-header:first-child, .ui-portlet .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-section .portlet-header:first-child, .ui-portlet-section .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-narrow .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-plain .portlet-header:first-child, .ui-portlet-plain .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .portlet-header:first-child {
+.accordion .card:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .card-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet .portlet-header:first-child, .ui-portlet .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-section .portlet-header:first-child, .ui-portlet-section .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-plain .portlet-header:first-child, .ui-portlet-plain .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .portlet-header:first-child {
   border-radius: 0; }
 
-.accordion .card:first-of-type, .accordion .ui-portlet:first-of-type, .accordion .ui-portlet-section:first-of-type, .accordion .ui-portlet-narrow:first-of-type, .accordion .ui-portlet-plain:first-of-type {
+.accordion .card:first-of-type, .accordion .ui-portlet:first-of-type, .accordion .ui-portlet-section:first-of-type, .accordion .ui-portlet-plain:first-of-type {
   border-bottom: 0;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0; }
 
-.accordion .card:last-of-type, .accordion .ui-portlet:last-of-type, .accordion .ui-portlet-section:last-of-type, .accordion .ui-portlet-narrow:last-of-type, .accordion .ui-portlet-plain:last-of-type {
+.accordion .card:last-of-type, .accordion .ui-portlet:last-of-type, .accordion .ui-portlet-section:last-of-type, .accordion .ui-portlet-plain:last-of-type {
   border-top-left-radius: 0;
   border-top-right-radius: 0; }
 
@@ -5611,7 +5570,7 @@ button.bg-dark:focus {
 .my-1 {
   margin-bottom: 0.25rem !important; }
 
-.ml-1, .ui-portlet .portlet-header .portlet-operations > *, .ui-portlet-section .portlet-header .portlet-operations > *, .ui-portlet-narrow .portlet-header .portlet-operations > *, .ui-portlet-plain .portlet-header .portlet-operations > *,
+.ml-1, .ui-portlet .portlet-header .portlet-operations > *, .ui-portlet-section .portlet-header .portlet-operations > *, .ui-portlet-plain .portlet-header .portlet-operations > *,
 .mx-1 {
   margin-left: 0.25rem !important; }
 
@@ -10645,12 +10604,12 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
   .ui-form-composite .ui-steps {
     overflow: auto; }
 
-.ui-portlet, .ui-portlet-section, .ui-portlet-narrow, .ui-portlet-plain {
+.ui-portlet, .ui-portlet-section, .ui-portlet-plain {
   height: 100%; }
-  .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible {
+  .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible {
     cursor: pointer;
     text-decoration: underline; }
-  .ui-portlet .portlet-backdrop, .ui-portlet-section .portlet-backdrop, .ui-portlet-narrow .portlet-backdrop, .ui-portlet-plain .portlet-backdrop {
+  .ui-portlet .portlet-backdrop, .ui-portlet-section .portlet-backdrop, .ui-portlet-plain .portlet-backdrop {
     display: none;
     z-index: 10;
     position: absolute;
@@ -10672,27 +10631,9 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     border-bottom: solid #dae0e5 1px;
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
-    padding: 0px 2px; }
+    padding: 5px; }
   .ui-portlet-section .portlet-content {
-    padding-right: 0px;
-    margin-left: 5px; }
-
-.ui-portlet-narrow {
-  border: none;
-  margin-bottom: 0.75rem; }
-  .ui-portlet-narrow .portlet-header {
-    border-radius: 0.1875rem; }
-    .ui-portlet-narrow .portlet-header .portlet-operations .ui-button-icon {
-      margin-left: 3px; }
-  .ui-portlet-narrow .ui-portlet-section .portlet-header {
-    border-radius: 0.3125rem;
-    border-bottom-left-radius: 0px;
-    border-top-left-radius: 0px; }
-  .ui-portlet-narrow .portlet-content {
-    padding: 0px; }
-  .ui-portlet-narrow .ui-table-section,
-  .ui-portlet-narrow .ui-portlet-section .portlet-content {
-    padding-left: 1rem; }
+    padding-right: 0px; }
 
 .ui-portlet-plain {
   border: none; }

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -3382,7 +3382,7 @@ button:not(:first-child),
     .navbar-dark .navbar-text a:hover, .navbar-dark .navbar-text a:focus {
       color: #fff; }
 
-.card, .ui-portlet, .ui-portlet-repeat, .ui-portlet-panel, .ui-portlet-section, .ui-portlet-limited, .ui-portlet-narrow, .ui-portlet-plain {
+.card, .ui-portlet, .ui-portlet-section, .ui-portlet-narrow, .ui-portlet-plain {
   position: relative;
   display: flex;
   flex-direction: column;
@@ -3392,17 +3392,17 @@ button:not(:first-child),
   background-clip: border-box;
   border: 1px solid rgba(0, 0, 0, 0.125);
   border-radius: 0.25rem; }
-  .card > hr, .ui-portlet > hr, .ui-portlet-repeat > hr, .ui-portlet-panel > hr, .ui-portlet-section > hr, .ui-portlet-limited > hr, .ui-portlet-narrow > hr, .ui-portlet-plain > hr {
+  .card > hr, .ui-portlet > hr, .ui-portlet-section > hr, .ui-portlet-narrow > hr, .ui-portlet-plain > hr {
     margin-right: 0;
     margin-left: 0; }
-  .card > .list-group:first-child .list-group-item:first-child, .ui-portlet > .list-group:first-child .list-group-item:first-child, .ui-portlet-repeat > .list-group:first-child .list-group-item:first-child, .ui-portlet-panel > .list-group:first-child .list-group-item:first-child, .ui-portlet-section > .list-group:first-child .list-group-item:first-child, .ui-portlet-limited > .list-group:first-child .list-group-item:first-child, .ui-portlet-narrow > .list-group:first-child .list-group-item:first-child, .ui-portlet-plain > .list-group:first-child .list-group-item:first-child {
+  .card > .list-group:first-child .list-group-item:first-child, .ui-portlet > .list-group:first-child .list-group-item:first-child, .ui-portlet-section > .list-group:first-child .list-group-item:first-child, .ui-portlet-narrow > .list-group:first-child .list-group-item:first-child, .ui-portlet-plain > .list-group:first-child .list-group-item:first-child {
     border-top-left-radius: 0.25rem;
     border-top-right-radius: 0.25rem; }
-  .card > .list-group:last-child .list-group-item:last-child, .ui-portlet > .list-group:last-child .list-group-item:last-child, .ui-portlet-repeat > .list-group:last-child .list-group-item:last-child, .ui-portlet-panel > .list-group:last-child .list-group-item:last-child, .ui-portlet-section > .list-group:last-child .list-group-item:last-child, .ui-portlet-limited > .list-group:last-child .list-group-item:last-child, .ui-portlet-narrow > .list-group:last-child .list-group-item:last-child, .ui-portlet-plain > .list-group:last-child .list-group-item:last-child {
+  .card > .list-group:last-child .list-group-item:last-child, .ui-portlet > .list-group:last-child .list-group-item:last-child, .ui-portlet-section > .list-group:last-child .list-group-item:last-child, .ui-portlet-narrow > .list-group:last-child .list-group-item:last-child, .ui-portlet-plain > .list-group:last-child .list-group-item:last-child {
     border-bottom-right-radius: 0.25rem;
     border-bottom-left-radius: 0.25rem; }
 
-.card-body, .ui-portlet .portlet-content, .ui-portlet-repeat .portlet-content, .ui-portlet-panel .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-limited .portlet-content, .ui-portlet-narrow .portlet-content, .ui-portlet-plain .portlet-content {
+.card-body, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-narrow .portlet-content, .ui-portlet-plain .portlet-content {
   flex: 1 1 auto;
   padding: 1.25rem; }
 
@@ -3422,14 +3422,14 @@ button:not(:first-child),
 .card-link + .card-link {
   margin-left: 1.25rem; }
 
-.card-header, .ui-portlet .portlet-header, .ui-portlet-repeat .portlet-header, .ui-portlet-panel .portlet-header, .ui-portlet-section .portlet-header, .ui-portlet-limited .portlet-header, .ui-portlet-narrow .portlet-header, .ui-portlet-plain .portlet-header {
+.card-header, .ui-portlet .portlet-header, .ui-portlet-section .portlet-header, .ui-portlet-narrow .portlet-header, .ui-portlet-plain .portlet-header {
   padding: 0.75rem 1.25rem;
   margin-bottom: 0;
   background-color: rgba(0, 0, 0, 0.03);
   border-bottom: 1px solid rgba(0, 0, 0, 0.125); }
-  .card-header:first-child, .ui-portlet .portlet-header:first-child, .ui-portlet-repeat .portlet-header:first-child, .ui-portlet-panel .portlet-header:first-child, .ui-portlet-section .portlet-header:first-child, .ui-portlet-limited .portlet-header:first-child, .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-plain .portlet-header:first-child {
+  .card-header:first-child, .ui-portlet .portlet-header:first-child, .ui-portlet-section .portlet-header:first-child, .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-plain .portlet-header:first-child {
     border-radius: calc(0.25rem - 1px) calc(0.25rem - 1px) 0 0; }
-  .card-header + .list-group .list-group-item:first-child, .ui-portlet .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-repeat .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-panel .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-section .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-limited .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-narrow .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-plain .portlet-header + .list-group .list-group-item:first-child {
+  .card-header + .list-group .list-group-item:first-child, .ui-portlet .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-section .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-narrow .portlet-header + .list-group .list-group-item:first-child, .ui-portlet-plain .portlet-header + .list-group .list-group-item:first-child {
     border-top: 0; }
 
 .card-footer {
@@ -3474,14 +3474,14 @@ button:not(:first-child),
 .card-deck {
   display: flex;
   flex-direction: column; }
-  .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-repeat, .card-deck .ui-portlet-panel, .card-deck .ui-portlet-section, .card-deck .ui-portlet-limited, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
+  .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
     margin-bottom: 15px; }
   @media (min-width: 576px) {
     .card-deck {
       flex-flow: row wrap;
       margin-right: -15px;
       margin-left: -15px; }
-      .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-repeat, .card-deck .ui-portlet-panel, .card-deck .ui-portlet-section, .card-deck .ui-portlet-limited, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
+      .card-deck .card, .card-deck .ui-portlet, .card-deck .ui-portlet-section, .card-deck .ui-portlet-narrow, .card-deck .ui-portlet-plain {
         display: flex;
         flex: 1 0 0%;
         flex-direction: column;
@@ -3492,341 +3492,170 @@ button:not(:first-child),
 .card-group {
   display: flex;
   flex-direction: column; }
-  .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-repeat, .card-group > .ui-portlet-panel, .card-group > .ui-portlet-section, .card-group > .ui-portlet-limited, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
+  .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
     margin-bottom: 15px; }
   @media (min-width: 576px) {
     .card-group {
       flex-flow: row wrap; }
-      .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-repeat, .card-group > .ui-portlet-panel, .card-group > .ui-portlet-section, .card-group > .ui-portlet-limited, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
+      .card-group > .card, .card-group > .ui-portlet, .card-group > .ui-portlet-section, .card-group > .ui-portlet-narrow, .card-group > .ui-portlet-plain {
         flex: 1 0 0%;
         margin-bottom: 0; }
-        .card-group > .card + .card, .card-group > .ui-portlet + .card, .card-group > .ui-portlet-repeat + .card, .card-group > .ui-portlet-panel + .card, .card-group > .ui-portlet-section + .card, .card-group > .ui-portlet-limited + .card, .card-group > .ui-portlet-narrow + .card, .card-group > .ui-portlet-plain + .card, .card-group > .card + .ui-portlet, .card-group > .ui-portlet + .ui-portlet, .card-group > .ui-portlet-repeat + .ui-portlet, .card-group > .ui-portlet-panel + .ui-portlet, .card-group > .ui-portlet-section + .ui-portlet, .card-group > .ui-portlet-limited + .ui-portlet, .card-group > .ui-portlet-narrow + .ui-portlet, .card-group > .ui-portlet-plain + .ui-portlet, .card-group > .card + .ui-portlet-repeat, .card-group > .ui-portlet + .ui-portlet-repeat, .card-group > .ui-portlet-repeat + .ui-portlet-repeat, .card-group > .ui-portlet-panel + .ui-portlet-repeat, .card-group > .ui-portlet-section + .ui-portlet-repeat, .card-group > .ui-portlet-limited + .ui-portlet-repeat, .card-group > .ui-portlet-narrow + .ui-portlet-repeat, .card-group > .ui-portlet-plain + .ui-portlet-repeat, .card-group > .card + .ui-portlet-panel, .card-group > .ui-portlet + .ui-portlet-panel, .card-group > .ui-portlet-repeat + .ui-portlet-panel, .card-group > .ui-portlet-panel + .ui-portlet-panel, .card-group > .ui-portlet-section + .ui-portlet-panel, .card-group > .ui-portlet-limited + .ui-portlet-panel, .card-group > .ui-portlet-narrow + .ui-portlet-panel, .card-group > .ui-portlet-plain + .ui-portlet-panel, .card-group > .card + .ui-portlet-section, .card-group > .ui-portlet + .ui-portlet-section, .card-group > .ui-portlet-repeat + .ui-portlet-section, .card-group > .ui-portlet-panel + .ui-portlet-section, .card-group > .ui-portlet-section + .ui-portlet-section, .card-group > .ui-portlet-limited + .ui-portlet-section, .card-group > .ui-portlet-narrow + .ui-portlet-section, .card-group > .ui-portlet-plain + .ui-portlet-section, .card-group > .card + .ui-portlet-limited, .card-group > .ui-portlet + .ui-portlet-limited, .card-group > .ui-portlet-repeat + .ui-portlet-limited, .card-group > .ui-portlet-panel + .ui-portlet-limited, .card-group > .ui-portlet-section + .ui-portlet-limited, .card-group > .ui-portlet-limited + .ui-portlet-limited, .card-group > .ui-portlet-narrow + .ui-portlet-limited, .card-group > .ui-portlet-plain + .ui-portlet-limited, .card-group > .card + .ui-portlet-narrow, .card-group > .ui-portlet + .ui-portlet-narrow, .card-group > .ui-portlet-repeat + .ui-portlet-narrow, .card-group > .ui-portlet-panel + .ui-portlet-narrow, .card-group > .ui-portlet-section + .ui-portlet-narrow, .card-group > .ui-portlet-limited + .ui-portlet-narrow, .card-group > .ui-portlet-narrow + .ui-portlet-narrow, .card-group > .ui-portlet-plain + .ui-portlet-narrow, .card-group > .card + .ui-portlet-plain, .card-group > .ui-portlet + .ui-portlet-plain, .card-group > .ui-portlet-repeat + .ui-portlet-plain, .card-group > .ui-portlet-panel + .ui-portlet-plain, .card-group > .ui-portlet-section + .ui-portlet-plain, .card-group > .ui-portlet-limited + .ui-portlet-plain, .card-group > .ui-portlet-narrow + .ui-portlet-plain, .card-group > .ui-portlet-plain + .ui-portlet-plain {
+        .card-group > .card + .card, .card-group > .ui-portlet + .card, .card-group > .ui-portlet-section + .card, .card-group > .ui-portlet-narrow + .card, .card-group > .ui-portlet-plain + .card, .card-group > .card + .ui-portlet, .card-group > .ui-portlet + .ui-portlet, .card-group > .ui-portlet-section + .ui-portlet, .card-group > .ui-portlet-narrow + .ui-portlet, .card-group > .ui-portlet-plain + .ui-portlet, .card-group > .card + .ui-portlet-section, .card-group > .ui-portlet + .ui-portlet-section, .card-group > .ui-portlet-section + .ui-portlet-section, .card-group > .ui-portlet-narrow + .ui-portlet-section, .card-group > .ui-portlet-plain + .ui-portlet-section, .card-group > .card + .ui-portlet-narrow, .card-group > .ui-portlet + .ui-portlet-narrow, .card-group > .ui-portlet-section + .ui-portlet-narrow, .card-group > .ui-portlet-narrow + .ui-portlet-narrow, .card-group > .ui-portlet-plain + .ui-portlet-narrow, .card-group > .card + .ui-portlet-plain, .card-group > .ui-portlet + .ui-portlet-plain, .card-group > .ui-portlet-section + .ui-portlet-plain, .card-group > .ui-portlet-narrow + .ui-portlet-plain, .card-group > .ui-portlet-plain + .ui-portlet-plain {
           margin-left: 0;
           border-left: 0; }
-        .card-group > .card:first-child, .card-group > .ui-portlet:first-child, .card-group > .ui-portlet-repeat:first-child, .card-group > .ui-portlet-panel:first-child, .card-group > .ui-portlet-section:first-child, .card-group > .ui-portlet-limited:first-child, .card-group > .ui-portlet-narrow:first-child, .card-group > .ui-portlet-plain:first-child {
+        .card-group > .card:first-child, .card-group > .ui-portlet:first-child, .card-group > .ui-portlet-section:first-child, .card-group > .ui-portlet-narrow:first-child, .card-group > .ui-portlet-plain:first-child {
           border-top-right-radius: 0;
           border-bottom-right-radius: 0; }
-          .card-group > .card:first-child .card-img-top, .card-group > .ui-portlet:first-child .card-img-top, .card-group > .ui-portlet-repeat:first-child .card-img-top, .card-group > .ui-portlet-panel:first-child .card-img-top, .card-group > .ui-portlet-section:first-child .card-img-top, .card-group > .ui-portlet-limited:first-child .card-img-top, .card-group > .ui-portlet-narrow:first-child .card-img-top, .card-group > .ui-portlet-plain:first-child .card-img-top,
+          .card-group > .card:first-child .card-img-top, .card-group > .ui-portlet:first-child .card-img-top, .card-group > .ui-portlet-section:first-child .card-img-top, .card-group > .ui-portlet-narrow:first-child .card-img-top, .card-group > .ui-portlet-plain:first-child .card-img-top,
           .card-group > .card:first-child .card-header,
           .card-group > .ui-portlet:first-child .card-header,
-          .card-group > .ui-portlet-repeat:first-child .card-header,
-          .card-group > .ui-portlet-panel:first-child .card-header,
           .card-group > .ui-portlet-section:first-child .card-header,
-          .card-group > .ui-portlet-limited:first-child .card-header,
           .card-group > .ui-portlet-narrow:first-child .card-header,
           .card-group > .ui-portlet-plain:first-child .card-header,
           .card-group > .card:first-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:first-child .portlet-header, .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-plain:first-child .portlet-header,
-          .card-group > .card:first-child .ui-portlet-repeat .portlet-header, .ui-portlet-repeat
-          .card-group > .card:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet:first-child .portlet-header, .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-plain:first-child .portlet-header,
-          .card-group > .card:first-child .ui-portlet-panel .portlet-header, .ui-portlet-panel
-          .card-group > .card:first-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-panel
           .card-group > .ui-portlet-plain:first-child .portlet-header,
           .card-group > .card:first-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet-section
+          .card-group > .ui-portlet:first-child .portlet-header, .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:first-child .portlet-header,
-          .card-group > .card:first-child .ui-portlet-limited .portlet-header, .ui-portlet-limited
-          .card-group > .card:first-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-section:first-child .portlet-header, .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-limited
           .card-group > .ui-portlet-plain:first-child .portlet-header,
           .card-group > .card:first-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
           .card-group > .card:first-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-narrow
+          .card-group > .ui-portlet-section:first-child .portlet-header, .card-group > .ui-portlet-narrow:first-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:first-child .portlet-header,
           .card-group > .card:first-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:first-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:first-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-repeat:first-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-panel:first-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-section:first-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-limited:first-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-narrow:first-child .portlet-header, .card-group > .ui-portlet-plain:first-child .portlet-header {
             border-top-right-radius: 0; }
-          .card-group > .card:first-child .card-img-bottom, .card-group > .ui-portlet:first-child .card-img-bottom, .card-group > .ui-portlet-repeat:first-child .card-img-bottom, .card-group > .ui-portlet-panel:first-child .card-img-bottom, .card-group > .ui-portlet-section:first-child .card-img-bottom, .card-group > .ui-portlet-limited:first-child .card-img-bottom, .card-group > .ui-portlet-narrow:first-child .card-img-bottom, .card-group > .ui-portlet-plain:first-child .card-img-bottom,
+          .card-group > .card:first-child .card-img-bottom, .card-group > .ui-portlet:first-child .card-img-bottom, .card-group > .ui-portlet-section:first-child .card-img-bottom, .card-group > .ui-portlet-narrow:first-child .card-img-bottom, .card-group > .ui-portlet-plain:first-child .card-img-bottom,
           .card-group > .card:first-child .card-footer,
           .card-group > .ui-portlet:first-child .card-footer,
-          .card-group > .ui-portlet-repeat:first-child .card-footer,
-          .card-group > .ui-portlet-panel:first-child .card-footer,
           .card-group > .ui-portlet-section:first-child .card-footer,
-          .card-group > .ui-portlet-limited:first-child .card-footer,
           .card-group > .ui-portlet-narrow:first-child .card-footer,
           .card-group > .ui-portlet-plain:first-child .card-footer {
             border-bottom-right-radius: 0; }
-        .card-group > .card:last-child, .card-group > .ui-portlet:last-child, .card-group > .ui-portlet-repeat:last-child, .card-group > .ui-portlet-panel:last-child, .card-group > .ui-portlet-section:last-child, .card-group > .ui-portlet-limited:last-child, .card-group > .ui-portlet-narrow:last-child, .card-group > .ui-portlet-plain:last-child {
+        .card-group > .card:last-child, .card-group > .ui-portlet:last-child, .card-group > .ui-portlet-section:last-child, .card-group > .ui-portlet-narrow:last-child, .card-group > .ui-portlet-plain:last-child {
           border-top-left-radius: 0;
           border-bottom-left-radius: 0; }
-          .card-group > .card:last-child .card-img-top, .card-group > .ui-portlet:last-child .card-img-top, .card-group > .ui-portlet-repeat:last-child .card-img-top, .card-group > .ui-portlet-panel:last-child .card-img-top, .card-group > .ui-portlet-section:last-child .card-img-top, .card-group > .ui-portlet-limited:last-child .card-img-top, .card-group > .ui-portlet-narrow:last-child .card-img-top, .card-group > .ui-portlet-plain:last-child .card-img-top,
+          .card-group > .card:last-child .card-img-top, .card-group > .ui-portlet:last-child .card-img-top, .card-group > .ui-portlet-section:last-child .card-img-top, .card-group > .ui-portlet-narrow:last-child .card-img-top, .card-group > .ui-portlet-plain:last-child .card-img-top,
           .card-group > .card:last-child .card-header,
           .card-group > .ui-portlet:last-child .card-header,
-          .card-group > .ui-portlet-repeat:last-child .card-header,
-          .card-group > .ui-portlet-panel:last-child .card-header,
           .card-group > .ui-portlet-section:last-child .card-header,
-          .card-group > .ui-portlet-limited:last-child .card-header,
           .card-group > .ui-portlet-narrow:last-child .card-header,
           .card-group > .ui-portlet-plain:last-child .card-header,
           .card-group > .card:last-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:last-child .portlet-header, .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-plain:last-child .portlet-header,
-          .card-group > .card:last-child .ui-portlet-repeat .portlet-header, .ui-portlet-repeat
-          .card-group > .card:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet:last-child .portlet-header, .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-plain:last-child .portlet-header,
-          .card-group > .card:last-child .ui-portlet-panel .portlet-header, .ui-portlet-panel
-          .card-group > .card:last-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-panel
           .card-group > .ui-portlet-plain:last-child .portlet-header,
           .card-group > .card:last-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet-section
+          .card-group > .ui-portlet:last-child .portlet-header, .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:last-child .portlet-header,
-          .card-group > .card:last-child .ui-portlet-limited .portlet-header, .ui-portlet-limited
-          .card-group > .card:last-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-section:last-child .portlet-header, .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-limited
           .card-group > .ui-portlet-plain:last-child .portlet-header,
           .card-group > .card:last-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
           .card-group > .card:last-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-narrow
+          .card-group > .ui-portlet-section:last-child .portlet-header, .card-group > .ui-portlet-narrow:last-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:last-child .portlet-header,
           .card-group > .card:last-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:last-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:last-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-repeat:last-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-panel:last-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-section:last-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-limited:last-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-narrow:last-child .portlet-header, .card-group > .ui-portlet-plain:last-child .portlet-header {
             border-top-left-radius: 0; }
-          .card-group > .card:last-child .card-img-bottom, .card-group > .ui-portlet:last-child .card-img-bottom, .card-group > .ui-portlet-repeat:last-child .card-img-bottom, .card-group > .ui-portlet-panel:last-child .card-img-bottom, .card-group > .ui-portlet-section:last-child .card-img-bottom, .card-group > .ui-portlet-limited:last-child .card-img-bottom, .card-group > .ui-portlet-narrow:last-child .card-img-bottom, .card-group > .ui-portlet-plain:last-child .card-img-bottom,
+          .card-group > .card:last-child .card-img-bottom, .card-group > .ui-portlet:last-child .card-img-bottom, .card-group > .ui-portlet-section:last-child .card-img-bottom, .card-group > .ui-portlet-narrow:last-child .card-img-bottom, .card-group > .ui-portlet-plain:last-child .card-img-bottom,
           .card-group > .card:last-child .card-footer,
           .card-group > .ui-portlet:last-child .card-footer,
-          .card-group > .ui-portlet-repeat:last-child .card-footer,
-          .card-group > .ui-portlet-panel:last-child .card-footer,
           .card-group > .ui-portlet-section:last-child .card-footer,
-          .card-group > .ui-portlet-limited:last-child .card-footer,
           .card-group > .ui-portlet-narrow:last-child .card-footer,
           .card-group > .ui-portlet-plain:last-child .card-footer {
             border-bottom-left-radius: 0; }
-        .card-group > .card:only-child, .card-group > .ui-portlet:only-child, .card-group > .ui-portlet-repeat:only-child, .card-group > .ui-portlet-panel:only-child, .card-group > .ui-portlet-section:only-child, .card-group > .ui-portlet-limited:only-child, .card-group > .ui-portlet-narrow:only-child, .card-group > .ui-portlet-plain:only-child {
+        .card-group > .card:only-child, .card-group > .ui-portlet:only-child, .card-group > .ui-portlet-section:only-child, .card-group > .ui-portlet-narrow:only-child, .card-group > .ui-portlet-plain:only-child {
           border-radius: 0.25rem; }
-          .card-group > .card:only-child .card-img-top, .card-group > .ui-portlet:only-child .card-img-top, .card-group > .ui-portlet-repeat:only-child .card-img-top, .card-group > .ui-portlet-panel:only-child .card-img-top, .card-group > .ui-portlet-section:only-child .card-img-top, .card-group > .ui-portlet-limited:only-child .card-img-top, .card-group > .ui-portlet-narrow:only-child .card-img-top, .card-group > .ui-portlet-plain:only-child .card-img-top,
+          .card-group > .card:only-child .card-img-top, .card-group > .ui-portlet:only-child .card-img-top, .card-group > .ui-portlet-section:only-child .card-img-top, .card-group > .ui-portlet-narrow:only-child .card-img-top, .card-group > .ui-portlet-plain:only-child .card-img-top,
           .card-group > .card:only-child .card-header,
           .card-group > .ui-portlet:only-child .card-header,
-          .card-group > .ui-portlet-repeat:only-child .card-header,
-          .card-group > .ui-portlet-panel:only-child .card-header,
           .card-group > .ui-portlet-section:only-child .card-header,
-          .card-group > .ui-portlet-limited:only-child .card-header,
           .card-group > .ui-portlet-narrow:only-child .card-header,
           .card-group > .ui-portlet-plain:only-child .card-header,
           .card-group > .card:only-child .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:only-child .portlet-header, .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet
           .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-plain:only-child .portlet-header,
-          .card-group > .card:only-child .ui-portlet-repeat .portlet-header, .ui-portlet-repeat
-          .card-group > .card:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet:only-child .portlet-header, .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-plain:only-child .portlet-header,
-          .card-group > .card:only-child .ui-portlet-panel .portlet-header, .ui-portlet-panel
-          .card-group > .card:only-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-panel
           .card-group > .ui-portlet-plain:only-child .portlet-header,
           .card-group > .card:only-child .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet-section
+          .card-group > .ui-portlet:only-child .portlet-header, .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:only-child .portlet-header,
-          .card-group > .card:only-child .ui-portlet-limited .portlet-header, .ui-portlet-limited
-          .card-group > .card:only-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-section:only-child .portlet-header, .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-limited
           .card-group > .ui-portlet-plain:only-child .portlet-header,
           .card-group > .card:only-child .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
           .card-group > .card:only-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-narrow
+          .card-group > .ui-portlet-section:only-child .portlet-header, .card-group > .ui-portlet-narrow:only-child .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:only-child .portlet-header,
           .card-group > .card:only-child .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:only-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:only-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-repeat:only-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-panel:only-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-section:only-child .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-limited:only-child .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-narrow:only-child .portlet-header, .card-group > .ui-portlet-plain:only-child .portlet-header {
             border-top-left-radius: 0.25rem;
             border-top-right-radius: 0.25rem; }
-          .card-group > .card:only-child .card-img-bottom, .card-group > .ui-portlet:only-child .card-img-bottom, .card-group > .ui-portlet-repeat:only-child .card-img-bottom, .card-group > .ui-portlet-panel:only-child .card-img-bottom, .card-group > .ui-portlet-section:only-child .card-img-bottom, .card-group > .ui-portlet-limited:only-child .card-img-bottom, .card-group > .ui-portlet-narrow:only-child .card-img-bottom, .card-group > .ui-portlet-plain:only-child .card-img-bottom,
+          .card-group > .card:only-child .card-img-bottom, .card-group > .ui-portlet:only-child .card-img-bottom, .card-group > .ui-portlet-section:only-child .card-img-bottom, .card-group > .ui-portlet-narrow:only-child .card-img-bottom, .card-group > .ui-portlet-plain:only-child .card-img-bottom,
           .card-group > .card:only-child .card-footer,
           .card-group > .ui-portlet:only-child .card-footer,
-          .card-group > .ui-portlet-repeat:only-child .card-footer,
-          .card-group > .ui-portlet-panel:only-child .card-footer,
           .card-group > .ui-portlet-section:only-child .card-footer,
-          .card-group > .ui-portlet-limited:only-child .card-footer,
           .card-group > .ui-portlet-narrow:only-child .card-footer,
           .card-group > .ui-portlet-plain:only-child .card-footer {
             border-bottom-right-radius: 0.25rem;
             border-bottom-left-radius: 0.25rem; }
-        .card-group > .card:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) {
+        .card-group > .card:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child), .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) {
           border-radius: 0; }
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
+          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-img-top, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-top,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-img-bottom,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-header,
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .card-header,
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-header,
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet .portlet-header, .ui-portlet
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet
-          .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-repeat .portlet-header, .ui-portlet-repeat
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-repeat
-          .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-panel .portlet-header, .ui-portlet-panel
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-panel
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-section .portlet-header, .ui-portlet-section
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
+          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-section
-          .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-limited .portlet-header, .ui-portlet-limited
-          .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
-          .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-limited
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-narrow .portlet-header, .ui-portlet-narrow
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
+          .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-narrow
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .ui-portlet-plain .portlet-header, .ui-portlet-plain
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .ui-portlet-plain
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .portlet-header, .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .portlet-header,
           .card-group > .card:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet:not(:first-child):not(:last-child):not(:only-child) .card-footer,
-          .card-group > .ui-portlet-repeat:not(:first-child):not(:last-child):not(:only-child) .card-footer,
-          .card-group > .ui-portlet-panel:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet-section:not(:first-child):not(:last-child):not(:only-child) .card-footer,
-          .card-group > .ui-portlet-limited:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet-narrow:not(:first-child):not(:last-child):not(:only-child) .card-footer,
           .card-group > .ui-portlet-plain:not(:first-child):not(:last-child):not(:only-child) .card-footer {
             border-radius: 0; } }
 
-.card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-repeat, .card-columns .ui-portlet-panel, .card-columns .ui-portlet-section, .card-columns .ui-portlet-limited, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
+.card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
   margin-bottom: 0.75rem; }
 
 @media (min-width: 576px) {
@@ -3835,23 +3664,23 @@ button:not(:first-child),
     column-gap: 1.25rem;
     orphans: 1;
     widows: 1; }
-    .card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-repeat, .card-columns .ui-portlet-panel, .card-columns .ui-portlet-section, .card-columns .ui-portlet-limited, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
+    .card-columns .card, .card-columns .ui-portlet, .card-columns .ui-portlet-section, .card-columns .ui-portlet-narrow, .card-columns .ui-portlet-plain {
       display: inline-block;
       width: 100%; } }
 
-.accordion .card:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-repeat:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-panel:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-section:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-limited:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-narrow:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-plain:not(:first-of-type):not(:last-of-type) {
+.accordion .card:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-section:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-narrow:not(:first-of-type):not(:last-of-type), .accordion .ui-portlet-plain:not(:first-of-type):not(:last-of-type) {
   border-bottom: 0;
   border-radius: 0; }
 
-.accordion .card:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-repeat:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-panel:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-limited:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .card-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet .portlet-header:first-child, .ui-portlet .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-repeat .portlet-header:first-child, .ui-portlet-repeat .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-repeat:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-panel .portlet-header:first-child, .ui-portlet-panel .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-panel:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-section .portlet-header:first-child, .ui-portlet-section .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-limited .portlet-header:first-child, .ui-portlet-limited .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-limited:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-narrow .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-plain .portlet-header:first-child, .ui-portlet-plain .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .portlet-header:first-child {
+.accordion .card:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .card-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .card-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet .portlet-header:first-child, .ui-portlet .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-section .portlet-header:first-child, .ui-portlet-section .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-section:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-narrow .portlet-header:first-child, .ui-portlet-narrow .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-narrow:not(:first-of-type) .portlet-header:first-child, .accordion .card:not(:first-of-type) .ui-portlet-plain .portlet-header:first-child, .ui-portlet-plain .accordion .card:not(:first-of-type) .portlet-header:first-child, .accordion .ui-portlet-plain:not(:first-of-type) .portlet-header:first-child {
   border-radius: 0; }
 
-.accordion .card:first-of-type, .accordion .ui-portlet:first-of-type, .accordion .ui-portlet-repeat:first-of-type, .accordion .ui-portlet-panel:first-of-type, .accordion .ui-portlet-section:first-of-type, .accordion .ui-portlet-limited:first-of-type, .accordion .ui-portlet-narrow:first-of-type, .accordion .ui-portlet-plain:first-of-type {
+.accordion .card:first-of-type, .accordion .ui-portlet:first-of-type, .accordion .ui-portlet-section:first-of-type, .accordion .ui-portlet-narrow:first-of-type, .accordion .ui-portlet-plain:first-of-type {
   border-bottom: 0;
   border-bottom-right-radius: 0;
   border-bottom-left-radius: 0; }
 
-.accordion .card:last-of-type, .accordion .ui-portlet:last-of-type, .accordion .ui-portlet-repeat:last-of-type, .accordion .ui-portlet-panel:last-of-type, .accordion .ui-portlet-section:last-of-type, .accordion .ui-portlet-limited:last-of-type, .accordion .ui-portlet-narrow:last-of-type, .accordion .ui-portlet-plain:last-of-type {
+.accordion .card:last-of-type, .accordion .ui-portlet:last-of-type, .accordion .ui-portlet-section:last-of-type, .accordion .ui-portlet-narrow:last-of-type, .accordion .ui-portlet-plain:last-of-type {
   border-top-left-radius: 0;
   border-top-right-radius: 0; }
 
@@ -5782,7 +5611,7 @@ button.bg-dark:focus {
 .my-1 {
   margin-bottom: 0.25rem !important; }
 
-.ml-1, .ui-portlet .portlet-header .portlet-operations > *, .ui-portlet-repeat .portlet-header .portlet-operations > *, .ui-portlet-panel .portlet-header .portlet-operations > *, .ui-portlet-section .portlet-header .portlet-operations > *, .ui-portlet-limited .portlet-header .portlet-operations > *, .ui-portlet-narrow .portlet-header .portlet-operations > *, .ui-portlet-plain .portlet-header .portlet-operations > *,
+.ml-1, .ui-portlet .portlet-header .portlet-operations > *, .ui-portlet-section .portlet-header .portlet-operations > *, .ui-portlet-narrow .portlet-header .portlet-operations > *, .ui-portlet-plain .portlet-header .portlet-operations > *,
 .mx-1 {
   margin-left: 0.25rem !important; }
 
@@ -10805,7 +10634,7 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     padding-left: 1rem; }
 
 .ui-form-section {
-  border-left: solid 3px #ebd9b2;
+  border-left: solid 3px #f8f9fa;
   border-radius: 0.3125rem !important;
   padding-left: 10px; }
 
@@ -10816,12 +10645,12 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
   .ui-form-composite .ui-steps {
     overflow: auto; }
 
-.ui-portlet, .ui-portlet-repeat, .ui-portlet-panel, .ui-portlet-section, .ui-portlet-limited, .ui-portlet-narrow, .ui-portlet-plain {
+.ui-portlet, .ui-portlet-section, .ui-portlet-narrow, .ui-portlet-plain {
   height: 100%; }
-  .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-repeat .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-panel .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-limited .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible {
+  .ui-portlet .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-section .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-narrow .portlet-header .portlet-title .portlet-title-text.collapsible, .ui-portlet-plain .portlet-header .portlet-title .portlet-title-text.collapsible {
     cursor: pointer;
     text-decoration: underline; }
-  .ui-portlet .portlet-backdrop, .ui-portlet-repeat .portlet-backdrop, .ui-portlet-panel .portlet-backdrop, .ui-portlet-section .portlet-backdrop, .ui-portlet-limited .portlet-backdrop, .ui-portlet-narrow .portlet-backdrop, .ui-portlet-plain .portlet-backdrop {
+  .ui-portlet .portlet-backdrop, .ui-portlet-section .portlet-backdrop, .ui-portlet-narrow .portlet-backdrop, .ui-portlet-plain .portlet-backdrop {
     display: none;
     z-index: 10;
     position: absolute;
@@ -10832,29 +10661,21 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     background: #fff;
     cursor: not-allowed; }
 
-.ui-portlet-repeat, .ui-portlet-panel, .ui-portlet-section {
+.ui-portlet-section {
   border: none;
-  border-left: solid 3px #ebd9b2;
+  border-left: solid 3px #f8f9fa;
   border-radius: 0.3125rem;
   margin-bottom: 0.375rem; }
-  .ui-portlet-repeat .portlet-header, .ui-portlet-panel .portlet-header, .ui-portlet-section .portlet-header {
-    background: #ebd9b2;
+  .ui-portlet-section .portlet-header {
+    background: #f8f9fa;
     border-radius: 0.3125rem;
+    border-bottom: solid #dae0e5 1px;
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
     padding: 0px 2px; }
-  .ui-portlet-repeat .portlet-content, .ui-portlet-panel .portlet-content, .ui-portlet-section .portlet-content {
-    padding-right: 0px; }
-
-.ui-portlet-panel, .ui-portlet-section {
-  margin-top: 0.375rem;
-  border-left: solid 3px #f8f9fa; }
-  .ui-portlet-panel .portlet-header, .ui-portlet-section .portlet-header {
-    background: #f8f9fa;
-    border-bottom: solid #dae0e5 1px; }
-
-.ui-portlet-section .portlet-highlight {
-  text-decoration: underline; }
+  .ui-portlet-section .portlet-content {
+    padding-right: 0px;
+    margin-left: 5px; }
 
 .ui-portlet-narrow {
   border: none;
@@ -10863,25 +10684,18 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     border-radius: 0.1875rem; }
     .ui-portlet-narrow .portlet-header .portlet-operations .ui-button-icon {
       margin-left: 3px; }
-  .ui-portlet-narrow .ui-portlet-repeat .portlet-header, .ui-portlet-narrow .ui-portlet-panel .portlet-header, .ui-portlet-narrow .ui-portlet-section .portlet-header {
+  .ui-portlet-narrow .ui-portlet-section .portlet-header {
     border-radius: 0.3125rem;
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px; }
   .ui-portlet-narrow .portlet-content {
     padding: 0px; }
   .ui-portlet-narrow .ui-table-section,
-  .ui-portlet-narrow .ui-portlet-repeat .portlet-content,
-  .ui-portlet-narrow .ui-portlet-panel .portlet-content,
   .ui-portlet-narrow .ui-portlet-section .portlet-content {
     padding-left: 1rem; }
 
-.ui-portlet-limited, .ui-portlet-narrow {
-  max-width: 900px; }
-
 .ui-portlet-plain {
   border: none; }
-  .ui-portlet-plain .portlet-content {
-    padding: 0px; }
 
 .ui-popover {
   max-width: 700px;
@@ -12558,8 +12372,7 @@ button.toast-close-button {
     .charts-client .charts-right .charts-editor .portlet-content {
       padding: 0px; }
     .charts-client .charts-right .charts-editor .ui-table-section,
-    .charts-client .charts-right .charts-editor .ui-portlet-panel .portlet-content,
-    .charts-client .charts-right .charts-editor .ui-portlet-section .portlet-content {
+    .charts-client .charts-right .charts-editor .ui-portlet-panel .portlet-content {
       padding-left: 5px; }
 
 .charts-client.charts-fullscreen .charts-buttons {

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -5585,7 +5585,7 @@ button.bg-dark:focus {
 .mx-2 {
   margin-right: 0.5rem !important; }
 
-.mb-2,
+.mb-2, .ui-portlet-section,
 .my-2 {
   margin-bottom: 0.5rem !important; }
 
@@ -5657,7 +5657,7 @@ button.bg-dark:focus {
 .py-0 {
   padding-top: 0 !important; }
 
-.pr-0, .ui-portlet-section .portlet-content,
+.pr-0,
 .px-0 {
   padding-right: 0 !important; }
 
@@ -5688,14 +5688,14 @@ button.bg-dark:focus {
 .px-1 {
   padding-left: 0.25rem !important; }
 
-.p-2 {
+.p-2, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content {
   padding: 0.5rem !important; }
 
 .pt-2,
 .py-2 {
   padding-top: 0.5rem !important; }
 
-.pr-2, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content,
+.pr-2,
 .px-2 {
   padding-right: 0.5rem !important; }
 
@@ -5703,7 +5703,7 @@ button.bg-dark:focus {
 .py-2 {
   padding-bottom: 0.5rem !important; }
 
-.pl-2, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content,
+.pl-2,
 .px-2 {
   padding-left: 0.5rem !important; }
 
@@ -10623,8 +10623,7 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
 .ui-portlet-section {
   border: none;
   border-left: solid 3px #e9ecef;
-  border-radius: 0.3125rem;
-  margin-bottom: 0.375rem; }
+  border-radius: 0.3125rem; }
   .ui-portlet-section .portlet-header {
     background: #e9ecef;
     border-radius: 0.3125rem;
@@ -10632,6 +10631,8 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
     padding: 5px; }
+  .ui-portlet-section .portlet-content {
+    padding-right: 0px !important; }
 
 .ui-portlet-plain {
   border: none; }

--- a/static/style/blue/base.css
+++ b/static/style/blue/base.css
@@ -5657,7 +5657,7 @@ button.bg-dark:focus {
 .py-0 {
   padding-top: 0 !important; }
 
-.pr-0,
+.pr-0, .ui-portlet-section .portlet-content,
 .px-0 {
   padding-right: 0 !important; }
 
@@ -5695,7 +5695,7 @@ button.bg-dark:focus {
 .py-2 {
   padding-top: 0.5rem !important; }
 
-.pr-2,
+.pr-2, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content,
 .px-2 {
   padding-right: 0.5rem !important; }
 
@@ -5703,7 +5703,7 @@ button.bg-dark:focus {
 .py-2 {
   padding-bottom: 0.5rem !important; }
 
-.pl-2,
+.pl-2, .ui-portlet .portlet-content, .ui-portlet-section .portlet-content, .ui-portlet-plain .portlet-content,
 .px-2 {
   padding-left: 0.5rem !important; }
 
@@ -10622,18 +10622,16 @@ html[dir="rtl"] .select2-container-multi .select2-search-choice-close {
 
 .ui-portlet-section {
   border: none;
-  border-left: solid 3px #f8f9fa;
+  border-left: solid 3px #e9ecef;
   border-radius: 0.3125rem;
   margin-bottom: 0.375rem; }
   .ui-portlet-section .portlet-header {
-    background: #f8f9fa;
+    background: #e9ecef;
     border-radius: 0.3125rem;
-    border-bottom: solid #dae0e5 1px;
+    border-bottom: solid #cbd3da 1px;
     border-bottom-left-radius: 0px;
     border-top-left-radius: 0px;
     padding: 5px; }
-  .ui-portlet-section .portlet-content {
-    padding-right: 0px; }
 
 .ui-portlet-plain {
   border: none; }


### PR DESCRIPTION
This PR follows up by consolidating the portlet styles into two classes (regular and subsections e.g. repeats and workflow steps). The PR reduces the degree of style customization by relying more on the bootstrap card style.